### PR TITLE
Close function without spirv-validation available

### DIFF
--- a/generator/src/main/resources/templates/asm-extinst-mapper.ftl
+++ b/generator/src/main/resources/templates/asm-extinst-mapper.ftl
@@ -11,7 +11,7 @@ import javax.annotation.Generated;
 @Generated("beehive-lab.spirv-proto.generator")
 class SPIRVExtInstMapper {
 
-    private static HashMap<String, Integer> extInstNameMap;
+    private static HashMap<String , Integer> extInstNameMap;
 
     /**
      * Get the number of the function mapped to the given name.

--- a/lib/src/main/java/uk/ac/manchester/spirvproto/lib/SPIRVModule.java
+++ b/lib/src/main/java/uk/ac/manchester/spirvproto/lib/SPIRVModule.java
@@ -122,6 +122,16 @@ public class SPIRVModule implements SPIRVInstScope {
     }
 
     /**
+     * Writes the ID max in the SPIRV Header and returns a reference to the writer.
+     * This method does not perform validation of the SPIRV module.
+     *
+     */
+    public SPIRVModuleWriter close() {
+        header.setBound(idGen.getCurrentBound());
+        return new SPIRVModuleWriter();
+    }
+
+    /**
      * Get the length of this module if written in binary format
      * @return The length of the binary
      */


### PR DESCRIPTION
Method for adding the reminder max ID in the SPIR-V header and return a reference to the writer handler without SPIR-V validation. This is useful for the initial codegen from TornadoVM 